### PR TITLE
Remake progress.py for more accurate function count

### DIFF
--- a/data/percent.json
+++ b/data/percent.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
 	"label": "decompiled",
-	"message": "0.0274%",
+	"message": "0.06790%",
 	"color": "blue"
 }

--- a/progress.py
+++ b/progress.py
@@ -1,35 +1,47 @@
-import math, os, sys
+import math, os, sys, csv
+
+TOTAL_GAME_SIZE = 0x7100A991D8 # Stop at the end of this
+
+total_size = 0 # Size of all functions that we count
+total_funcs = 0 # Amount of functions
+completed_funcs = 0 # Size of completed functions
+
+prev_address = 0
+
+# Start of the symbol for functions we want to skip
+skip_funcs = ("_ZN2nn", "_ZThn32_N2nn", "_ZN4sead")
 
 def truncate(number, digits) -> float:
     stepper = 10.0 ** digits
     return math.trunc(stepper * number) / stepper
 
-done_size = 0
-TOTAL_GAME_SIZE = 0xA991D8
+with open('data/functions.csv', 'r') as f:
+    reader = csv.reader(f)
 
-func_sizes = { }
+    next(reader)
 
-with open("data/funcSizes.txt", "r") as f:
-    lines = f.readlines()
+    for row in reader:
+        address, symbol_name, matching = row
+        total_funcs += 1
 
-for line in lines:
-    spl = line.split("=")
-    func_sizes[spl[0]] = spl[1].replace("\n", "")
+        if symbol_name.startswith(skip_funcs):
+            continue
+        else:
+            func_size = int(address, 16) - prev_address
+            total_size += func_size
+            prev_address = int(address, 16)
+            
+            if matching == "true":
+                completed_funcs += 1
 
-with open("data/functions.csv", "r") as f:
-    csvData = f.readlines()
 
-for c in csvData:
-    spl = c.split(",")
-    isDone = spl[2].replace("\n", "")
-    
-    if isDone == "true":
-        funcSize = func_sizes[spl[1]]
-        done_size = done_size + int(funcSize)
+        if total_size >= TOTAL_GAME_SIZE:
+            break
 
-prog = (done_size / TOTAL_GAME_SIZE) * 100.0
+prog = (completed_funcs / total_funcs) * 100
+
 print("Progress:")
-print(f"{prog}% [{done_size} / {TOTAL_GAME_SIZE}]")
+print(f"{prog:.5f}% [{completed_funcs} / {total_funcs}]")
 
 print("Generating JSON...")
 

--- a/progress.py
+++ b/progress.py
@@ -11,10 +11,6 @@ prev_address = 0
 # Start of the symbol for functions we want to skip
 skip_funcs = ("_ZN2nn", "_ZThn32_N2nn", "_ZN4sead")
 
-def truncate(number, digits) -> float:
-    stepper = 10.0 ** digits
-    return math.trunc(stepper * number) / stepper
-
 with open('data/functions.csv', 'r') as f:
     reader = csv.reader(f)
 
@@ -50,7 +46,7 @@ json = []
 json.append("{\n")
 json.append("\t\"schemaVersion\": 1,\n")
 json.append("\t\"label\": \"decompiled\",\n")
-json.append(f"\t\"message\": \"{truncate(prog, 4)}%\",\n")
+json.append(f"\t\"message\": \"{prog:.5f}%\",\n")
 json.append("\t\"color\": \"blue\"\n")
 json.append("}")
 


### PR DESCRIPTION
Currently, the progress script uses every function up until `0xA991D8`. This includes many nn::nex and sead functions that we will not work on in this repo. When fixing this, I took it as a chance to switch the code over to the `csv` module for an cleaner time parsing the data. This also removes the need for the `funcSizes.txt` but I'm not sure if you plan to use that elsewhere.